### PR TITLE
Getting StatsD Backend to work with v2.0 endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/blueflood');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "statsd-blueflood-backend",
   "description": "blueflood statsD backend",
   "author": "Gary Dusbabek <gdusbabek@gmail.com>",
-  "version": "0.0.1",
+  "version": "0.0.2",
+  "main": "lib/blueflood.js",
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
1. The major fix is adding the v2.0 aggregated metrics endpoint. 
2. Added index.js file - without it, we could not get this module to install in statsd
