### PR TITLE
Sending all sub-metrics for a timer

### DIFF
--- a/lib/metric_utils.js
+++ b/lib/metric_utils.js
@@ -78,7 +78,7 @@ function extractTimers(metrics) {
       sum: metrics.timer_data[name].sum == null ? 0 : metrics.timer_data[name].sum,
       avg: metrics.timer_data[name].mean == null ? 0 : metrics.timer_data[name].mean,
       median: metrics.timer_data[name].median == null ? 0 : metrics.timer_data[name].median,
-      std: metrics.timer_data[name].std == null ? 0 : metrics.timer_data[name].median
+      std: metrics.timer_data[name].std == null ? 0 : metrics.timer_data[name].std
     };
     if (hasPercentiles) {
       timers[name].percentiles = {};


### PR DESCRIPTION
Statsd does not send all sub-metrics for a timer that was seen during a previous flush interval, but is not seen in the current flush interval. 

for eg: if glork was not seen in the current interval statsd will send us this - glork: { count_ps: 0, count: 0 }

However, Blueflood expects all sub-metrics to be present and errors out if it doesnt see any. Therefore, we fixed the blueflood backend to send all sub-metrics zeroed out, if they are not present in the statsd payload

Also  users of this backend should use the deleteIdleStats option in the statsd config https://github.com/etsy/statsd/blob/master/exampleConfig.js#L47
