### PR TITLE
fix(npm): Add an index.js so that this module can be imported more sanely

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/blueflood');

--- a/lib/blueflood.js
+++ b/lib/blueflood.js
@@ -36,7 +36,7 @@ function bluefloodConfigOk(conf, logger) {
     logger.log('Missing tenantId', 'LOG_ERR');
     return false;
   }
-  
+
   if (!conf.hasOwnProperty('endpoint')) {
     logger.log('Missing BF API endpoint', 'LOG_ERR');
     return false;
@@ -76,7 +76,7 @@ exports.init = function (startupTime, config, events, logger) {
     endpoint,
     flushIntervalMillis = null,
     auth;
-  
+
   // ensure some kind of logging.
   if (typeof logger !== 'undefined') {
     realLogger = logger;
@@ -85,35 +85,35 @@ exports.init = function (startupTime, config, events, logger) {
     console.log('module logger is not defined')
     realLogger = util;
   }
-  
+
   // ensure there is a blueflood configuration.
   if (!config.hasOwnProperty('blueflood')) {
     realLogger.log('No configuration for Blueflood');
     return false;
   }
-  
+
   // get the blueflood configuration and verify it.
   bfConfig = config.blueflood;
   if (!bluefloodConfigOk(bfConfig, realLogger)) {
     return false;
   }
-  
+
   if (config.hasOwnProperty('flushInterval')) {
     flushIntervalMillis = config.flushInterval;
   }
-  
+
   // we're good from here on out.
-  
+
   endpoint = config.blueflood.endpoint || cmendpoint;
-  
+
   auth = loadAuth(config.blueflood, realLogger);
-  
+
   globalBackend = new StaticTenantBackend(bfConfig.tenantId, endpoint, flushIntervalMillis, realLogger, bfConfig.maxjsonsize, auth);
   backendClass = StaticTenantBackend;
-  
+
   // bind here.
   events.on('flush', backendClass.prototype.flush.bind(globalBackend));
   events.on('status', backendClass.prototype.flush.bind(globalBackend));
-    
+
   return true;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "statsd-blueflood-backend",
   "description": "blueflood statsD backend",
-  "author": "Gary Dusbabek <gdusbabek@gmail.com>, George Jahad <george.jahad@rackspace.com>, Tilottama Gaat <tilottama.gaat@rackspace.com>",
+  "author": [
+    "Gary Dusbabek <gdusbabek@gmail.com>",
+    "George Jahad <george.jahad@rackspace.com>",
+    "Tilottama Gaat <tilottama.gaat@rackspace.com>",
+    "Justin Gallardo <justin.gallardo@rackspace.com>"
+  ],
   "version": "0.0.3",
   "main": "lib/blueflood.js",
   "dependencies": {


### PR DESCRIPTION
Currently to add this as a statsd backend, you would need to specify the path to the `blueflood.js` file in the `lib` directory of the module.

By adding `index.js`, now the user can just add the path to the root module directory in their statsd config.

For example, if you ran `npm install statsd-blueflood-backend` inside of your StatsD directory, you'd be able to use the following config:

```javascript
{
  "backends": ["./node_modules/blueflood-statsd-backend"]
{
```

I also shamelessly added myself as a contributor and removed some trailing whitespace.