### PR TITLE
Fixed the issue related to 503 error.

### DIFF
--- a/lib/blueflood_http_client.js
+++ b/lib/blueflood_http_client.js
@@ -142,6 +142,14 @@ function buildPayloads(tenantId, timestamp, gauges, counters, timers, sets, flus
   Object.keys(payloadObj).forEach(function(label) {
     payloadObj[label].forEach(function(metric) {
       objLength = JSON.stringify(metric).length;
+
+      // Add length for a ',' because if collection contains more than one item,
+      // JSON stringification will add a ',' between every two objects
+      // Assumption: label will always be 'gauges', 'counters', 'timers', and/or 'sets'
+      if(basePayload[label].length > 0){
+        objLength++;
+      }
+
       // if objLength > realMax, we will end up sending a bundle that is too large. we'll let the client deal with
       // that. there isn't much we can do about it.
       if (curJsonSize + objLength > realMax) {
@@ -157,6 +165,7 @@ function buildPayloads(tenantId, timestamp, gauges, counters, timers, sets, flus
           sets: []
         }
         curJsonSize = basePayloadLength;
+        objLength = JSON.stringify(metric).length;
       }
       basePayload[label].push(metric);
       curJsonSize += objLength;
@@ -211,6 +220,7 @@ function postMetrics(
   payloads.forEach(function(payload) {
     // kinda hacky, but hey...
     options.headers['Content-Length'] = payload.length;
+    log.log("Metrics payload length is " + payload.length);
     postRaw(options, transport, payload, log, 0, auth);
   });
 }

--- a/lib/blueflood_http_client.js
+++ b/lib/blueflood_http_client.js
@@ -164,6 +164,7 @@ function buildPayloads(tenantId, timestamp, gauges, counters, timers, sets, flus
           timers: [],
           sets: []
         }
+        // Reset size for curJsonSize and objLength
         curJsonSize = basePayloadLength;
         objLength = JSON.stringify(metric).length;
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Tilottama Gaat <tilottama.gaat@rackspace.com>",
     "Justin Gallardo <justin.gallardo@rackspace.com>"
   ],
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "lib/blueflood.js",
   "dependencies": {
     "request": "2.45.0"


### PR DESCRIPTION
Issue (from https://jira.rax.io/browse/CMC-2003):
Current blueflood-statsd-backend implementation limits the aggregated metrics payload length to 1MB while flushing the data to Rackspace metrics API. Because of this limitation, many metrics-flush from RBA results in 503 response status from Rackspace metrics API. Can the 1MB payload limitation be relaxed to allow up to larger values (example: 5MB)?
This limitation is the major pain point as of now. RBA publishes numerous metrics and aggregating them at 1 minute is crossing the 1MB limit. Hence most of the metrics flush calls fail to reach Rackspace metrics.

Root Cause:
Length of commas were not getting added into the payload while looping through the metrics collection. So, when there are hundreds (or may be thousands) of elements are there in the collection, final payload size in way more than max allowed. Because of this, when final payload is sent to Blueflood, it rejects because it is bigger than the max aloud.

Resolution:
Added logic for adding the size of every comma during the loop. Also, added related test cases, it lacked test cases to test the business logic on the max size.